### PR TITLE
Add LTI configuration for grader

### DIFF
--- a/rootfs/srv/db-aplus-bootstrap.py
+++ b/rootfs/srv/db-aplus-bootstrap.py
@@ -127,6 +127,16 @@ def create_default_services():
         consumer_secret="rubyric",
     )
 
+    services['grader'] = LTIService.objects.create(
+        url="http://grader:8080/",
+        destination_region=0,
+        menu_label="Grader",
+        menu_icon_class="save-file",
+        access_settings=5,
+        consumer_key="grader",
+        consumer_secret="grader",
+    )
+
     return services
 
 


### PR DESCRIPTION
Relevant once the mooc-grader updates become available via run-mooc-grader: supports testing with exercises that have enabled lti-parameters for mooc-grader.