### PR TITLE
Add Redis service for Celery and silence Flower spam

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN : \
  && create-db.sh aplus aplus django-migrate.sh \
  \
  && mkdir -p /var/celery/results \
- && chown aplus:nogroup /var/celery/results \
+ && chown -R aplus:nogroup /var/celery \
  && :
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN : \
       python3-lxml \
       python3-lz4 \
       python3-pillow \
+      redis \
 \
   # create user
  && adduser --system --no-create-home --disabled-password --gecos "A+ webapp server,,," --home /srv/aplus --ingroup nogroup aplus \

--- a/rootfs/etc/cont-init.d/aplus
+++ b/rootfs/etc/cont-init.d/aplus
@@ -17,3 +17,5 @@ ensure_dir /local/lti-services-in 2777 root root
 # The IP address with the .1 ending should be the host machine's IP address in
 # the Docker network, in other words, the IP address of the client (web browser).
 echo '["'$(hostname -i | cut -s -d. -f1-3)'.1"]' > /var/run/s6/container_environment/APLUS_INTERNAL_IPS
+
+echo "127.0.0.1 redis" >> /etc/hosts

--- a/rootfs/etc/services.d/celery/run
+++ b/rootfs/etc/services.d/celery/run
@@ -21,4 +21,4 @@ s6-env HOME=${home}
 cd ${home}
 
 # Start celery daemon
-${python3} -m debugpy --listen 0.0.0.0:5679 -m celery -A aplus worker --loglevel=debug --concurrency 1 --hostname worker_main@aplus --beat --task-events
+${python3} -m debugpy --listen 0.0.0.0:5679 -m celery -A aplus worker --loglevel=debug --concurrency 1 --hostname worker_main@aplus --beat --task-events --schedule /var/celery/celerybeat-schedule

--- a/rootfs/etc/services.d/flower/run
+++ b/rootfs/etc/services.d/flower/run
@@ -3,6 +3,7 @@
 define user aplus
 define home /srv/${user}
 #define daemon /usr/bin/epmd
+# Using stdout instead of stderr
 fdmove -c 2 1
 
 # (-s is undocumented magic, that seems to move _prog_ to end of _then_ or
@@ -20,4 +21,4 @@ s6-env HOME=${home}
 cd ${home}
 
 # Start daemon
-${python3} -m celery -A aplus flower --address=0.0.0.0
+${python3} -m celery -A aplus flower --address=0.0.0.0 --enable_events=False

--- a/rootfs/etc/services.d/redis/run
+++ b/rootfs/etc/services.d/redis/run
@@ -1,0 +1,18 @@
+#!/bin/execlineb -P
+
+define user redis
+define home /var/lib/redis
+#define daemon /usr/bin/epmd
+# Using stdout instead of stderr
+fdmove -c 2 1
+
+# Use container environment
+with-contenv
+
+# user and workdir
+s6-setuidgid $user
+s6-env HOME=${home}
+cd ${home}
+
+# Start daemon
+redis-server --save 60 1 --loglevel warning


### PR DESCRIPTION
# Description

**What?**

A separate Redis container is no longer needed for Celery because Redis is now included.
Additionally, event message spam every 5 seconds from Flower is silenced.

Celery could not create ``celerybeat-schedule.db`` file to locally mounted A+ directory, because it is considered read-only.
This db file is now moved to ``/var/celery/`` so that Celery can create is even when a local directory is mounted for A+ development.

**Why?**

Now courses don't need to modify the ``docker-compose.yml`` by adding a Redis service, since it is included in ``run-aplus-front`` container and constant spam in the terminal from Flower was annoying.