### PR TITLE
Use the latest version of django-debug-toolbar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN : \
   # install requirements, remove the file, remove unrequired locales and tests
  && pip_install \
       -r requirements.txt \
-      "django-debug-toolbar >= 3.8.1" \
+      "django-debug-toolbar >= 6.1.0, < 7" \
       flower \
  && rm requirements.txt \
  && find /usr/local/lib/python* -type d -regex '.*/locale/[a-z_A-Z]+' -not -regex '.*/\(en\|fi\|sv\)' -print0 | xargs -0 rm -rf \


### PR DESCRIPTION
# Description

Install the 6.1.0 or later version of django-debug-toolbar to get support for debug_toolbar.middleware.show_toolbar_with_docker callback (available since 6.0.0), which finally offers a way to get the DJDT to show up consistently in a Docker environment without custom workarounds in settings.py.